### PR TITLE
feat: add reordering feature for viewer sections

### DIFF
--- a/src/viewer/Viewer.jsx
+++ b/src/viewer/Viewer.jsx
@@ -1,16 +1,115 @@
+import { useState, useEffect, Fragment } from 'react';
 import ViewerGeneral from './components/ViewerGeneral';
 import ViewerNonGeneral from './components/ViewerNonGeneral';
 import ViewerOthers from './components/ViewerOthers';
+import ShiftUpIcon from '../assets/shift-up.svg?react';
+import ShiftDownIcon from '../assets/shift-down.svg?react';
 import PropTypes from 'prop-types';
 
 const Viewer = ({ cvData }) => {
+    // console.log(cvData);
+
+    // Initial order of components
+    const [viewOrder, setViewOrder] = useState([]);
+
+    useEffect(() => {
+        setViewOrder([
+            { type: 'ViewerGeneral', data: cvData.generalInfo },
+            { type: 'ViewerNonGeneral', data: cvData.educationHistory },
+            { type: 'ViewerNonGeneral', data: cvData.experienceHistory },
+            { type: 'ViewerOthers', data: cvData.skillsList },
+            { type: 'ViewerOthers', data: cvData.projectsList },
+        ]);
+    }, [cvData]);
+
+    // Reorder the components when up/down button is clicked
+    const reorderComponents = (index, direction, viewOrder, setViewOrder) => {
+        if ((direction === 'up' && index === 0) || (direction === 'down' && index === viewOrder.length - 1)) {
+            return; // Do nothing if shifting first section up, or last section down.
+        }
+
+        const newIndex = direction === 'up' ? index - 1 : index + 1;
+        const newOrder = [...viewOrder];
+        [newOrder[index], newOrder[newIndex]] = [newOrder[newIndex], newOrder[index]]; // Swap adjacent places
+        setViewOrder(newOrder);
+    };
+
+    // Conditionally render the correct component based on type (General, NonGeneral, Others)
+    const renderComponent = (component, index, viewOrder, setViewOrder) => {
+        // console.log(component);
+        const isEmpty = (component) =>
+            Array.isArray(component.data)
+                ? component.data.length === 0
+                : typeof component.data === 'object' &&
+                  component.data !== null &&
+                  Object.keys(component.data).length === 0;
+
+        // console.log(isEmpty(component));
+        switch (component.type) {
+            case 'ViewerGeneral':
+                return (
+                    !isEmpty(component) && (
+                        <>
+                            <div className="flex relative">
+                                <ViewerGeneral info={component.data} />
+                                <div className="absolute right-0">
+                                    <button onClick={() => reorderComponents(index, 'up', viewOrder, setViewOrder)}>
+                                        <ShiftUpIcon className="w-8 h-auto hover:scale-110" />
+                                    </button>
+                                    <button onClick={() => reorderComponents(index, 'down', viewOrder, setViewOrder)}>
+                                        <ShiftDownIcon className="w-8 h-auto hover:scale-110" />
+                                    </button>
+                                </div>
+                            </div>
+                        </>
+                    )
+                );
+            case 'ViewerNonGeneral':
+                return (
+                    !isEmpty(component) && (
+                        <>
+                            <div className="flex relative">
+                                <ViewerNonGeneral nonGeneralSection={component.data} />
+                                <div className="absolute right-0">
+                                    <button onClick={() => reorderComponents(index, 'up', viewOrder, setViewOrder)}>
+                                        <ShiftUpIcon className="w-8 h-auto hover:scale-110" />
+                                    </button>
+                                    <button onClick={() => reorderComponents(index, 'down', viewOrder, setViewOrder)}>
+                                        <ShiftDownIcon className="w-8 h-auto hover:scale-110" />
+                                    </button>
+                                </div>
+                            </div>
+                        </>
+                    )
+                );
+            case 'ViewerOthers':
+                return (
+                    !isEmpty(component) && (
+                        <>
+                            <div className="flex relative">
+                                <ViewerOthers otherSection={component.data} />
+                                <div className="absolute right-0">
+                                    <button onClick={() => reorderComponents(index, 'up', viewOrder, setViewOrder)}>
+                                        <ShiftUpIcon className="w-8 h-auto hover:scale-110" />
+                                    </button>
+                                    <button onClick={() => reorderComponents(index, 'down', viewOrder, setViewOrder)}>
+                                        <ShiftDownIcon className="w-8 h-auto hover:scale-110" />
+                                    </button>
+                                </div>
+                            </div>
+                        </>
+                    )
+                );
+            default:
+                return null;
+        }
+    };
+
     return (
         <section className="p-6 w-full md:w-2/3 border border-regent-st-blue-400 bg-white my-4 rounded-md md:mx-4 md:max-h-full md:aspect-[210/297]">
-            <ViewerGeneral info={cvData.generalInfo} />
-            <ViewerNonGeneral nonGeneralSection={cvData.educationHistory} />
-            <ViewerNonGeneral nonGeneralSection={cvData.experienceHistory} />
-            <ViewerOthers otherSection={cvData.skillsList} />
-            <ViewerOthers otherSection={cvData.projectsList} />
+            {viewOrder.map((component, index) => (
+                <Fragment key={index}>{renderComponent(component, index, viewOrder, setViewOrder)}</Fragment>
+            ))}
         </section>
     );
 };


### PR DESCRIPTION
Add a viewOrder state variable to maintain the
selected section order.

Add a pair of buttons to each section in the
Viewer to update the section order.

---
name: Pull Request
about: Add ability to reorder the sections in the resume viewer
title: 'Feature: Reordering of resume sections'
labels: enhancement
assignees: @kevinweejh 
---

**Related Issue(s)**
#1 

**Problem / Motivation**
Job applicants are encouraged to cater each resume specific to their application. The customisation extends to ordering the resume sections to prioritise the most important sections by placing them closer to the top.   

**Solution**
Add Up/Down buttons to each resume section in the Viewer. Users can freely reorder their sections to best meet their needs for the specific job that they are applying to.   

**Testing Done**
TBD

**Screenshots**
![issue-1-fix-01](https://github.com/kevinweejh/resu-me/assets/34761000/c4fbaad4-5131-4827-8915-08746abf929c)
![issue-1-fix-02](https://github.com/kevinweejh/resu-me/assets/34761000/2e9fdc6a-9163-407e-b0ba-7366e50687f9)


**Checklist:**

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes

**Additional Notes**
NIL
