### PR TITLE
fix: eliminate section width dependence on content

### DIFF
--- a/src/viewer/components/ViewerGeneral.jsx
+++ b/src/viewer/components/ViewerGeneral.jsx
@@ -6,7 +6,7 @@ const ViewerGeneral = ({ info }) => {
     return (
         <>
             {isObjectFilled && (
-                <section className="flex flex-col text-center mb-2">
+                <section className="flex flex-col grow text-center mb-2">
                     <h1 className="text-2xl font-semibold">
                         {info.firstName} {info.lastName}
                     </h1>

--- a/src/viewer/components/ViewerNonGeneral.jsx
+++ b/src/viewer/components/ViewerNonGeneral.jsx
@@ -15,7 +15,7 @@ const ViewerNonGeneral = ({ nonGeneralSection }) => {
     return (
         <>
             {isArrayFilled && isObjectFilled && (
-                <section className="flex flex-col mb-2">
+                <section className="flex flex-col grow mb-2">
                     <h1 className="text-2xl font-semibold">{formType === 'education' ? 'Education' : 'Experience'}</h1>
                     <hr></hr>
                     {nonGeneralSection.map((nonGeneralSectionItem) => (

--- a/src/viewer/components/ViewerOthers.jsx
+++ b/src/viewer/components/ViewerOthers.jsx
@@ -15,7 +15,7 @@ const ViewerOthers = ({ otherSection }) => {
     return (
         <>
             {isArrayFilled && isObjectFilled && (
-                <section className="flex flex-col mb-2">
+                <section className="flex flex-col grow mb-2">
                     <h1 className="text-2xl font-semibold">{formType === 'skills' ? 'Skills' : 'Projects'}</h1>
                     <hr></hr>
                     {otherSection.map((otherSectionItem) => (


### PR DESCRIPTION
Since the 3 Viewer subcomponents are flexboxes,
and flex-direction defaults to 'row', the content
of each flex item only takes up as much horizontal space as it needs.

As such, the ViewerGeneral section shown in
issue #3 does not take up full width, since its
content does not actually fill the full width.

This dependence on the content length is
eliminated by setting `flex-grow: 1` on the
section container.

---
name: Pull Request
about: Eliminate section width dependence on content
title: 'Bug Fix: Eliminate section width dependence on content length'
labels: enhancement
assignees: @kevinweejh 
---

**Related Issue(s)**
#3 

**Problem / Motivation**
Previously, due to the nature of flexbox, the width of sections in `Viewer` were dependent on the width of the content enclosed. This caused alignment issues for the `ViewerGeneral` component, which is styled to be center-aligned to the document, which would be off to the left if the content did not fill the entire width. 

**Solution**
Add the `flex-grow: 1` styling to the sections, so that their widths would grow to fill the full-width always. This eliminates the section width's dependence on the content width, while still using the flexbox layout.

**Testing Done**
Visual inspection using Chrome DevTools for the following devices/viewports:

- iPhone XR
- iPhone 14 Pro Max
- Samsung Galaxy S8+
- Samsung Galaxy S20 Ultra
- iPad Mini
- iPad Air
- Desktop [1280px x 1209px]
- Desktop [2560px x 1209px]

**Screenshots**
![image](https://github.com/kevinweejh/resu-me/assets/34761000/613084e3-8634-42a9-9256-71057bbab0ae)

**Checklist:**

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes

**Additional Notes**
NIL
