### PR TITLE
fix: use empty string instead of null

### DIFF
--- a/src/customiser/components/CustomiserGeneral.jsx
+++ b/src/customiser/components/CustomiserGeneral.jsx
@@ -9,18 +9,18 @@ import TooltipIcon from '../../assets/tooltip.svg?react';
 const CustomiserGeneral = ({ info, setInfo }) => {
     const [mobile, setMobile] = useState(null); // As required for PhoneInput component
     const [form, setForm] = useState({
-        firstName: null,
-        lastName: null,
-        email: null,
-        mobile: null,
+        firstName: '',
+        lastName: '',
+        email: '',
+        mobile: '',
         portfolioInputVis: false,
-        portfolio: null,
+        portfolio: '',
         gitHubInputVis: false,
-        gitHub: null,
+        gitHub: '',
         stateInputVis: false,
-        state: null,
+        state: '',
         cityInputVis: false,
-        city: null,
+        city: '',
     });
 
     const handleChange = (e) => {

--- a/src/customiser/components/CustomiserNonGeneral.jsx
+++ b/src/customiser/components/CustomiserNonGeneral.jsx
@@ -11,18 +11,18 @@ const CustomiserNonGeneral = ({ nonGeneralSection, setNonGeneralSection, formTyp
     const [idCounter, setIdCounter] = useState(0);
 
     const [form, setForm] = useState({
-        orgName: null,
-        position: null,
+        orgName: '',
+        position: '',
         currentStatus: false,
     });
 
-    const [startDate, setStartDate] = useState(null);
-    const [endDate, setEndDate] = useState(null);
+    const [startDate, setStartDate] = useState('');
+    const [endDate, setEndDate] = useState('');
 
     const [achievementsList, setAchievementsList] = useState([]);
     const [achievementIdCounter, setAchievementIdCounter] = useState(0);
 
-    const [editingId, setEditingId] = useState(null);
+    const [editingId, setEditingId] = useState('');
 
     const [order, setOrder] = useState([]);
 
@@ -57,11 +57,11 @@ const CustomiserNonGeneral = ({ nonGeneralSection, setNonGeneralSection, formTyp
         e.preventDefault();
 
         const addedNonGeneralItem = {
-            id: editingId !== null ? editingId : idCounter,
+            id: editingId !== '' ? editingId : idCounter,
             orgName: form.orgName,
             position: form.position,
-            yearFrom: startDate ? startDate.format('MMM YYYY') : null,
-            yearTo: endDate ? endDate.format('MMM YYYY') : null,
+            yearFrom: startDate ? startDate.format('MMM YYYY') : '',
+            yearTo: endDate ? endDate.format('MMM YYYY') : '',
             currentStatus: form.currentStatus,
             achievementsList: achievementsList,
             formType: formType,
@@ -69,7 +69,7 @@ const CustomiserNonGeneral = ({ nonGeneralSection, setNonGeneralSection, formTyp
 
         let newNonGeneralSectionHistory;
 
-        if (editingId !== null) {
+        if (editingId !== '') {
             // Editing -> Replace the existing entry with edited entry
             newNonGeneralSectionHistory = nonGeneralSection.map((nonGeneralSectionItem) => {
                 return nonGeneralSectionItem.id === editingId ? addedNonGeneralItem : nonGeneralSectionItem;
@@ -85,14 +85,14 @@ const CustomiserNonGeneral = ({ nonGeneralSection, setNonGeneralSection, formTyp
 
         setForm({
             ...form,
-            orgName: null,
-            position: null,
+            orgName: '',
+            position: '',
             currentStatus: false,
         });
-        setStartDate(null);
-        setEndDate(null);
+        setStartDate('');
+        setEndDate('');
         setAchievementsList([]);
-        setEditingId(null);
+        setEditingId('');
         e.target.reset();
     };
 
@@ -103,8 +103,8 @@ const CustomiserNonGeneral = ({ nonGeneralSection, setNonGeneralSection, formTyp
             position: entry.position,
             currentStatus: entry.currentStatus,
         });
-        setStartDate(entry.yearFrom ? dayjs(entry.yearFrom, 'MMM YYYY') : null);
-        setEndDate(entry.yearTo ? dayjs(entry.yearTo, 'MMM YYYY') : null);
+        setStartDate(entry.yearFrom ? dayjs(entry.yearFrom, 'MMM YYYY') : '');
+        setEndDate(entry.yearTo ? dayjs(entry.yearTo, 'MMM YYYY') : '');
         setAchievementsList(entry.achievementsList);
 
         setEditingId(entry.id);
@@ -159,7 +159,7 @@ const CustomiserNonGeneral = ({ nonGeneralSection, setNonGeneralSection, formTyp
                             id="orgName"
                             name="orgName"
                             placeholder={formType === 'education' ? 'Enter school name' : 'Enter company name'}
-                            value={form.orgName || null}
+                            value={form.orgName || ''}
                             onChange={handleChange}
                         ></input>
                         <div className="flex gap-2 mt-2">
@@ -193,7 +193,7 @@ const CustomiserNonGeneral = ({ nonGeneralSection, setNonGeneralSection, formTyp
                                     ? 'Enter your course of studies'
                                     : 'Enter your position or title'
                             }
-                            value={form.position || null}
+                            value={form.position || ''}
                             onChange={handleChange}
                         ></input>
                         <div className="grid grid-cols-8 gap-2 items-center mt-2">
@@ -206,8 +206,8 @@ const CustomiserNonGeneral = ({ nonGeneralSection, setNonGeneralSection, formTyp
                                             format="MMM YYYY"
                                             views={['year', 'month']}
                                             name="yearFromInput"
-                                            value={startDate ? dayjs(startDate) : null}
-                                            onChange={(newValue) => setStartDate(newValue ? dayjs(newValue) : null)}
+                                            value={startDate ? dayjs(startDate) : ''}
+                                            onChange={(newValue) => setStartDate(newValue ? dayjs(newValue) : '')}
                                         />
                                     </div>
                                 </>
@@ -231,8 +231,8 @@ const CustomiserNonGeneral = ({ nonGeneralSection, setNonGeneralSection, formTyp
                                         format="MMM YYYY"
                                         views={['year', 'month']}
                                         name="yearToInput"
-                                        value={endDate ? dayjs(endDate) : null}
-                                        onChange={(newValue) => setEndDate(newValue ? dayjs(newValue) : null)}
+                                        value={endDate ? dayjs(endDate) : ''}
+                                        onChange={(newValue) => setEndDate(newValue ? dayjs(newValue) : '')}
                                         disabled={form.currentStatus}
                                     />
                                 )}
@@ -261,7 +261,7 @@ const CustomiserNonGeneral = ({ nonGeneralSection, setNonGeneralSection, formTyp
                             type="submit"
                             className="border text-lg font-semibold text-center rounded-md w-fit mt-4 ml-auto px-4 py-2 text-regent-st-blue-50 bg-regent-st-blue-500 hover:bg-regent-st-blue-600 active:bg-regent-st-blue-700 hover:cursor-pointer"
                         >
-                            {editingId !== null ? 'Save Entry' : 'Add Entry'}
+                            {editingId !== '' ? 'Save Entry' : 'Add Entry'}
                         </button>
                     </form>
                 </div>

--- a/src/customiser/components/CustomiserOthers.jsx
+++ b/src/customiser/components/CustomiserOthers.jsx
@@ -8,13 +8,13 @@ import TooltipIcon from '../../assets/tooltip.svg?react';
 const CustomiserOther = ({ otherSection, setOtherSection, formType }) => {
     const [idCounter, setIdCounter] = useState(0);
 
-    const [title, setTitle] = useState(null);
-    const [link, setLink] = useState(null);
+    const [title, setTitle] = useState('');
+    const [link, setLink] = useState('');
 
     const [detailsList, setDetailsList] = useState([]);
     const [detailIdCounter, setDetailIdCounter] = useState(0);
 
-    const [editingId, setEditingId] = useState(null);
+    const [editingId, setEditingId] = useState('');
 
     const [order, setOrder] = useState([]);
 
@@ -40,16 +40,16 @@ const CustomiserOther = ({ otherSection, setOtherSection, formType }) => {
         e.preventDefault();
 
         const addedOtherItem = {
-            id: editingId !== null ? editingId : idCounter,
+            id: editingId !== '' ? editingId : idCounter,
             title: e.target.titleInput.value,
-            link: formType !== 'skills' ? e.target.linkInput.value : null,
+            link: formType !== 'skills' ? e.target.linkInput.value : '',
             detailsList: detailsList,
             formType: formType,
         };
 
         let newOtherSectionHistory;
 
-        if (editingId !== null) {
+        if (editingId !== '') {
             // Editing -> Replace the existing entry with edited entry
             newOtherSectionHistory = otherSection.map((otherSectionItem) => {
                 return otherSectionItem.id === editingId ? addedOtherItem : otherSectionItem;
@@ -63,10 +63,10 @@ const CustomiserOther = ({ otherSection, setOtherSection, formType }) => {
 
         setOtherSection(newOtherSectionHistory);
 
-        setTitle(null);
-        setLink(null);
+        setTitle('');
+        setLink('');
         setDetailsList([]);
-        setEditingId(null);
+        setEditingId('');
         e.target.reset();
     };
 
@@ -145,7 +145,7 @@ const CustomiserOther = ({ otherSection, setOtherSection, formType }) => {
                             id="titleInput"
                             name="titleInput"
                             placeholder={formType === 'skills' ? 'Enter skill category' : 'Enter project title'}
-                            value={title || null}
+                            value={title || ''}
                             onChange={(e) => setTitle(e.target.value)}
                         ></input>
                         {formType === 'projects' && (
@@ -162,7 +162,7 @@ const CustomiserOther = ({ otherSection, setOtherSection, formType }) => {
                                     id="linkInput"
                                     name="linkInput"
                                     placeholder="Enter your project URL"
-                                    value={link || null}
+                                    value={link || ''}
                                     onChange={(e) => setLink(e.target.value)}
                                 ></input>
                             </>
@@ -177,7 +177,7 @@ const CustomiserOther = ({ otherSection, setOtherSection, formType }) => {
                             type="submit"
                             className="border text-lg font-semibold text-center rounded-md w-fit mt-4 ml-auto px-4 py-2 text-regent-st-blue-50 bg-regent-st-blue-500 hover:bg-regent-st-blue-600 active:bg-regent-st-blue-700 hover:cursor-pointer"
                         >
-                            {editingId !== null ? 'Save Entry' : 'Add Entry'}
+                            {editingId !== '' ? 'Save Entry' : 'Add Entry'}
                         </button>
                     </form>
                 </div>


### PR DESCRIPTION
Swap out all state variables' initial default
value from null to empty string '' for `useState`
hooks that do not deal with Date objects.

Do the same for when the associated updater
functions are called for form resets.

Exception made for state variables dealing with
Date objects as those are properly dealt with
by the dayjs library.

---
name: Pull Request
about: Fix console errors relating to use of null with state variables
title: 'Feature: Form state variables returning console errors fixed'
labels: enhancement
assignees: @kevinweejh 
---

**Related Issue(s)**
#5 

**Problem / Motivation**
While there has been no reports of errors in usage, this PR eliminates the console errors caused by the use of `null` in state variables used in the form elements. 

**Solution**
Replace `null` with an empty string '' when initialising and updating text-based state variables. Exception made for state variables dealing with Data objects, as those are properly managed by the dayjs library. 

**Testing Done**
Checked against Chrome DevTools after clearing cookies. Error message in Console no longer returned. 

**Screenshots**
NIL

**Checklist:**

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes

**Additional Notes**
NIL
