### PR TITLE
fix: add name and short_name members

### DIFF
--- a/src/assets/site.webmanifest
+++ b/src/assets/site.webmanifest
@@ -1,1 +1,11 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+    "name": "resu-me; Resume Generator Web App",
+    "short_name": "re-sume",
+    "icons": [
+        { "src": "/android-chrome-192x192.png", "sizes": "192x192", "type": "image/png" },
+        { "src": "/android-chrome-512x512.png", "sizes": "512x512", "type": "image/png" }
+    ],
+    "theme_color": "#ffffff",
+    "background_color": "#ffffff",
+    "display": "standalone"
+}


### PR DESCRIPTION
Previously, the `name` and `short_name` members
were empty strings. This caused the browser to
return the syntax error.

As such, providing `name` and `short_name` members eliminates the syntax error.

---
name: Pull Request
about: Add missing info to sitemanifest
title: 'Feature: Add missing info to sitemanifest'
labels: enhancement
assignees: @kevinweejh 
---

**Related Issue(s)**
#8 

**Problem / Motivation**
On page load, the Console will log a syntax error. The cause was identified to be due to missing information in the `site.webmanifest` file. 

**Solution**
Provide suitable `name` and `short_name` member data in the `site.webmanifest` file. 

**Testing Done**
Run new page load in Incognito Mode to avoid complications with browser cache. Syntax error is not longer logged. 

**Screenshots**
NIL

**Checklist:**

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes

**Additional Notes**
NIL
