### PR TITLE
fix: use useRef hook instead of querySelector

### DIFF
--- a/src/customiser/components/CustomiserGeneral.jsx
+++ b/src/customiser/components/CustomiserGeneral.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import 'react-phone-number-input/style.css';
 import PhoneInput from 'react-phone-number-input';
 import { formatPhoneNumberIntl, parsePhoneNumber } from 'react-phone-number-input';
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { Tooltip } from 'react-tooltip';
 import TooltipIcon from '../../assets/tooltip.svg?react';
 
@@ -22,6 +22,8 @@ const CustomiserGeneral = ({ info, setInfo }) => {
         cityInputVis: false,
         city: '',
     });
+
+    const generalTabRef = useRef(null); // For closing the 'General' tab on save
 
     const handleChange = (e) => {
         // Handle 'checkbox' and value inputs accordingly
@@ -53,13 +55,14 @@ const CustomiserGeneral = ({ info, setInfo }) => {
         };
         setInfo(updatedGeneralInfo);
 
-        const generalTab = document.querySelector('#generalTab');
-        generalTab.removeAttribute('open');
+        // Automatically closes the 'General' tab on save
+        // 'General' tab rarely needs further adjustments after initial input
+        generalTabRef.current.removeAttribute('open');
     };
 
     return (
         <>
-            <details data-testid="generalTab" id="generalTab">
+            <details data-testid="generalTab" ref={generalTabRef}>
                 <summary className="flex flex-col rounded-t-md p-2 text-2xl font-semibold text-center bg-regent-st-blue-500 text-regent-st-blue-50 md:text-left hover:cursor-pointer hover:bg-regent-st-blue-600 active:bg-regent-st-blue-700">
                     General
                 </summary>


### PR DESCRIPTION
The useRef hook provided by React is referred for
DOM manipulation over document object API methods
as it helps to avoid unexpected behaviors like
race conditions, web accessibility issues, and
inefficient re-renders.

---
name: Pull Request
about: Replace querySelector with useRef hook
title: 'Feature: useRef hook for DOM manipulation'
labels: enhancement
assignees: @kevinweejh 
---

**Related Issue(s)**
#10 

**Problem / Motivation**
This is a pre-emptive bug fix to use the React useRef() hook for DOM manipulation. This better aligns with React best practices. 

**Solution**
Replace the `querySelector` method use in the `handleGeneralInfoSave` function with a ref. The ref needs to be declared at the top level of the `CustomiserGeneral` component, using the `useRef()` hook. From there, the `removeAttribute` method can be called on the ref instead of the previous `querySelector` value.  

**Testing Done**
Manual clickthrough using Chrome DevTools for the following devices/viewports:

iPhone 14 Pro Max
Samsung Galaxy S20 Ultra
iPad Air
Desktop [1280px x 1209px]

**Screenshots**
N.A.

**Checklist:**

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes

**Additional Notes**
For additional details on why useRef hook is preferred for DOM manipulation: [Reference](https://www.meje.dev/blog/useref-not-queryselector)
